### PR TITLE
fix: align manifest plugin ID with runtime export

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,5 +1,5 @@
 {
-  "id": "wecom-openclaw-plugin",
+  "id": "wecom",
   "channels": [
     "wecom"
   ],


### PR DESCRIPTION
## Summary

- 修复 `openclaw.plugin.json` 中插件 ID (`wecom-openclaw-plugin`) 与运行时导出 ID (`wecom`) 不一致的 bug
- Fix plugin ID mismatch between manifest file and runtime export in `index.ts`

Closes #41

## Details / 详情

manifest 文件声明的 ID 为 `"wecom-openclaw-plugin"`，而 `index.ts` 运行时导出的插件 ID 为 `"wecom"`，导致安装后插件无法被正确解析，需手动修正配置。

The manifest declared `"wecom-openclaw-plugin"` as the plugin ID, but the runtime export in `index.ts` uses `"wecom"`, causing plugin resolution failures after installation.

## Changes / 变更

- `openclaw.plugin.json`: `"id": "wecom-openclaw-plugin"` → `"id": "wecom"`

## Test plan

- [ ] 验证插件安装后无需手动修改 `openclaw.json` 中的插件引用
- [ ] 确认 `openclaw.plugin.json` 的 ID 与 `index.ts` 导出的 ID 一致