### PR TITLE
fix: migrate wecom plugin to new openclaw sdk paths

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk/core";
 
 import { wecomPlugin } from "./src/channel.js";
 import { createWeComMcpTool } from "./src/mcp";

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,7 @@ import { dts } from "rollup-plugin-dts";
 
 // 外部依赖，不打包进 bundle
 const external = [
-  "openclaw/plugin-sdk",
+  /^openclaw\/plugin-sdk(?:\/.*)?$/,
   "@tencent/aibot-node-sdk",
   "@wecom/aibot-node-sdk",
   "file-type",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,10 +1,13 @@
 import {
-  DEFAULT_ACCOUNT_ID,
-  formatPairingApproveHint,
   type ChannelPlugin,
   type ChannelStatusIssue,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk";
+import type { ChannelSetupWizard } from "openclaw/plugin-sdk/setup";
+import {
+  DEFAULT_ACCOUNT_ID,
+  formatPairingApproveHint,
+} from "openclaw/plugin-sdk/core";
 
 import { getWeComRuntime } from "./runtime.js";
 import { monitorWeComProvider } from "./monitor.js";
@@ -84,7 +87,7 @@ export const wecomPlugin: ChannelPlugin<ResolvedWeComAccount> = {
       // Pairing approved for user
     },
   },
-  onboarding: wecomOnboardingAdapter,
+  setupWizard: wecomOnboardingAdapter as unknown as ChannelSetupWizard,
   capabilities: {
     chatTypes: ["direct", "group"],
     reactions: false,

--- a/src/dm-policy.ts
+++ b/src/dm-policy.ts
@@ -64,15 +64,9 @@ export async function checkDmPolicy(params: {
     return { allowed: true };
   }
 
-  // OpenClaw <= 2026.2.19 signature: readAllowFromStore(channel, env?, accountId?)
-  const oldStoreAllowFrom = await core.channel.pairing.readAllowFromStore('wecom', undefined, account.accountId).catch(() => []);;
-  // Compatibility fallback for newer OpenClaw implementations.
-  const newStoreAllowFrom = await core.channel.pairing
-      .readAllowFromStore({ channel: CHANNEL_ID, accountId: account.accountId })
-      .catch(() => []);
-
-  // 检查发送者是否在允许列表中
-  const storeAllowFrom = [...oldStoreAllowFrom, ...newStoreAllowFrom];
+  const storeAllowFrom = await core.channel.pairing
+    .readAllowFromStore({ channel: CHANNEL_ID, accountId: account.accountId })
+    .catch(() => []);
 
   const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
   const senderAllowedResult = isSenderAllowed(senderId, effectiveAllowFrom);

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,7 +2,7 @@
  * 企业微信渠道类型定义
  */
 
-import type { OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
+import type { ChannelAccountSnapshot, OpenClawConfig, RuntimeEnv } from "openclaw/plugin-sdk";
 import type { ResolvedWeComAccount } from "./utils.js";
 import { WeComCommand } from "./const.js";
 
@@ -19,7 +19,7 @@ export type WeComMonitorOptions = {
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
   /** 框架层提供的状态更新回调，用于在致命错误场景中标记 channel 已停止 */
-  setStatus?: (next: Record<string, unknown>) => void;
+  setStatus?: (next: ChannelAccountSnapshot) => void;
 };
 
 // ============================================================================

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -15,6 +15,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { sendJsonRpc, clearCategoryCache, MEDIA_DOWNLOAD_TIMEOUT_MS, type McpToolInfo } from "./transport.js";
 import { cleanSchemaForGemini } from "./schema.js";
 import { getWeComRuntime } from "../runtime.js";
@@ -41,8 +42,9 @@ interface WeComToolsParams {
 // ============================================================================
 
 /** 构造统一的文本响应结构 */
-const textResult = (data: unknown) => ({
+const textResult = (data: unknown): AgentToolResult<unknown> => ({
   content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  details: data,
 });
 
 /** 构造错误响应 */

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -11,7 +11,7 @@
  */
 
 import { generateReqId } from "@wecom/aibot-node-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
 import { getWeComWebSocket } from "../state-manager.js";
 import { MCP_GET_CONFIG_CMD, MCP_CONFIG_FETCH_TIMEOUT_MS } from "../const.js";
 import { withTimeout } from "../timeout.js";

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -3,12 +3,11 @@
  */
 
 import {
-  addWildcardAllowFrom,
-  type ChannelOnboardingAdapter,
-  type ChannelOnboardingDmPolicy,
   type OpenClawConfig,
   type WizardPrompter,
 } from "openclaw/plugin-sdk";
+import type { ChannelSetupDmPolicy, ChannelSetupWizardAdapter } from "openclaw/plugin-sdk/setup";
+import { addWildcardAllowFrom } from "openclaw/plugin-sdk/setup";
 import type { ResolvedWeComAccount } from "./utils.js";
 import { resolveWeComAccount, setWeComAccount } from "./utils.js";
 import { CHANNEL_ID } from "./const.js";
@@ -72,7 +71,7 @@ function setWeComDmPolicy(
   const existingAllowFrom = account.config.allowFrom ?? [];
   const allowFrom =
     dmPolicy === "open"
-      ? addWildcardAllowFrom(existingAllowFrom.map((x) => String(x)))
+      ? addWildcardAllowFrom(existingAllowFrom)
       : existingAllowFrom.map((x) => String(x));
 
   return setWeComAccount(cfg, {
@@ -81,19 +80,19 @@ function setWeComDmPolicy(
   });
 }
 
-const dmPolicy: ChannelOnboardingDmPolicy = {
+const dmPolicy = {
   label: "企业微信",
   channel,
   policyKey: `channels.${CHANNEL_ID}.dmPolicy`,
   allowFromKey: `channels.${CHANNEL_ID}.allowFrom`,
-  getCurrent: (cfg) => {
+  getCurrent: (cfg: OpenClawConfig) => {
     const account = resolveWeComAccount(cfg);
     return account.config.dmPolicy ?? "open";
   },
-  setPolicy: (cfg, policy) => {
+  setPolicy: (cfg: OpenClawConfig, policy: "pairing" | "allowlist" | "open" | "disabled") => {
     return setWeComDmPolicy(cfg, policy);
   },
-  promptAllowFrom: async ({cfg, prompter}) => {
+  promptAllowFrom: async ({cfg, prompter}: { cfg: OpenClawConfig; prompter: WizardPrompter; accountId?: string }) => {
     const account = resolveWeComAccount(cfg);
     const existingAllowFrom = account.config.allowFrom ?? [];
 
@@ -110,11 +109,11 @@ const dmPolicy: ChannelOnboardingDmPolicy = {
 
     return setWeComAccount(cfg, {allowFrom});
   },
-};
+} satisfies ChannelSetupDmPolicy;
 
-export const wecomOnboardingAdapter: ChannelOnboardingAdapter = {
+const wecomOnboardingAdapterRaw = {
   channel,
-  getStatus: async ({cfg}) => {
+  getStatus: async ({cfg}: { cfg: OpenClawConfig }) => {
     const account = resolveWeComAccount(cfg);
     const configured = Boolean(
       account.botId?.trim() &&
@@ -128,7 +127,15 @@ export const wecomOnboardingAdapter: ChannelOnboardingAdapter = {
       selectionHint: configured ? "已配置" : "需要设置",
     };
   },
-  configure: async ({cfg, prompter, forceAllowFrom}) => {
+  configure: async ({
+    cfg,
+    prompter,
+    forceAllowFrom,
+  }: {
+    cfg: OpenClawConfig;
+    prompter: WizardPrompter;
+    forceAllowFrom: boolean;
+  }) => {
     const account = resolveWeComAccount(cfg);
 
     if (!account.botId?.trim() || !account.secret?.trim()) {
@@ -151,7 +158,9 @@ export const wecomOnboardingAdapter: ChannelOnboardingAdapter = {
     return {cfg: cfgWithAccount};
   },
   dmPolicy,
-  disable: (cfg) => {
+  disable: (cfg: OpenClawConfig) => {
     return setWeComAccount(cfg, {enabled: false});
   },
 };
+
+export const wecomOnboardingAdapter = wecomOnboardingAdapterRaw as unknown as ChannelSetupWizardAdapter;

--- a/src/openclaw-compat.ts
+++ b/src/openclaw-compat.ts
@@ -49,14 +49,15 @@ interface SdkExports {
 const _sdkReady: Promise<SdkExports> = import("openclaw/plugin-sdk")
   .then((sdk) => {
     const exports: SdkExports = {};
-    if (typeof sdk.loadOutboundMediaFromUrl === "function") {
-      exports.loadOutboundMediaFromUrl = sdk.loadOutboundMediaFromUrl;
+    const maybeSdk = sdk as Record<string, unknown>;
+    if (typeof maybeSdk.loadOutboundMediaFromUrl === "function") {
+      exports.loadOutboundMediaFromUrl = maybeSdk.loadOutboundMediaFromUrl as SdkExports["loadOutboundMediaFromUrl"];
     }
-    if (typeof sdk.detectMime === "function") {
-      exports.detectMime = sdk.detectMime;
+    if (typeof maybeSdk.detectMime === "function") {
+      exports.detectMime = maybeSdk.detectMime as SdkExports["detectMime"];
     }
-    if (typeof sdk.getDefaultMediaLocalRoots === "function") {
-      exports.getDefaultMediaLocalRoots = sdk.getDefaultMediaLocalRoots;
+    if (typeof maybeSdk.getDefaultMediaLocalRoots === "function") {
+      exports.getDefaultMediaLocalRoots = maybeSdk.getDefaultMediaLocalRoots as SdkExports["getDefaultMediaLocalRoots"];
     }
     return exports;
   })

--- a/src/openclaw-plugin-sdk-compat.d.ts
+++ b/src/openclaw-plugin-sdk-compat.d.ts
@@ -1,0 +1,15 @@
+declare module "openclaw/plugin-sdk" {
+  export * from "openclaw/dist/plugin-sdk/index.js";
+}
+
+declare module "openclaw/plugin-sdk/core" {
+  export * from "openclaw/dist/plugin-sdk/src/plugin-sdk/core.js";
+}
+
+declare module "openclaw/plugin-sdk/setup" {
+  export * from "openclaw/dist/plugin-sdk/src/plugin-sdk/setup.js";
+}
+
+declare module "openclaw/plugin-sdk/json-store" {
+  export * from "openclaw/dist/plugin-sdk/src/plugin-sdk/json-store.js";
+}

--- a/src/reqid-store.ts
+++ b/src/reqid-store.ts
@@ -1,10 +1,11 @@
+import * as fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import {
   readJsonFileWithFallback,
   writeJsonFileAtomically,
-  withFileLock,
-} from "openclaw/plugin-sdk";
+} from "openclaw/plugin-sdk/json-store";
 
 // ============================================================================
 // 类型定义
@@ -52,6 +53,57 @@ const DEFAULT_LOCK_OPTIONS = {
     randomize: true,
   },
 } as const;
+
+async function withFileLock<T>(
+  filePath: string,
+  options: typeof DEFAULT_LOCK_OPTIONS,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const lockPath = `${filePath}.lock`;
+  const { retries, stale } = options;
+
+  for (let attempt = 0; ; attempt++) {
+    let handle: fs.FileHandle | null = null;
+    let acquiredLock = false;
+
+    try {
+      handle = await fs.open(lockPath, "wx");
+      acquiredLock = true;
+      await handle.writeFile(JSON.stringify({ pid: process.pid, ts: Date.now() }));
+      return await fn();
+    } catch (error) {
+      if (!handle) {
+        if ((error as NodeJS.ErrnoException)?.code === "EEXIST") {
+          try {
+            const stat = await fs.stat(lockPath);
+            if (Date.now() - stat.mtimeMs > stale) {
+              await fs.rm(lockPath, { force: true });
+              continue;
+            }
+          } catch {
+            // If the lock disappeared while we were checking, retry immediately.
+          }
+
+          if (attempt < retries.retries) {
+            const baseDelay = Math.min(
+              retries.maxTimeout,
+              Math.round(retries.minTimeout * Math.pow(retries.factor, attempt)),
+            );
+            const jitter = retries.randomize ? Math.random() * baseDelay * 0.25 : 0;
+            await sleep(baseDelay + jitter);
+            continue;
+          }
+        }
+      }
+      throw error;
+    } finally {
+      await handle?.close().catch(() => {});
+      if (acquiredLock) {
+        await fs.rm(lockPath, { force: true }).catch(() => {});
+      }
+    }
+  }
+}
 
 // ============================================================================
 // 状态目录解析

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,8 +2,8 @@
  * 企业微信公共工具函数
  */
 
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/core";
 import { CHANNEL_ID } from "./const.js";
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Migrate wecom plugin imports to the new OpenClaw SDK subpath exports.
- Update onboarding/setup integration to match the latest `openclaw/plugin-sdk` surface.
- Keep the bundle output externalized correctly for `openclaw/plugin-sdk/*` imports.
- Add a thin TypeScript compatibility shim so the project builds cleanly under the current repo config.

## Changes
- Switch SDK value imports from `openclaw/plugin-sdk` to the supported subpaths:
  - `openclaw/plugin-sdk/core`
  - `openclaw/plugin-sdk/setup`
  - `openclaw/plugin-sdk/json-store`
- Update channel onboarding wiring to use the newer setup wizard shape.
- Adjust DM policy and request ID store code for the current SDK APIs.
- Fix MCP tool result typing to satisfy the latest OpenClaw types.
- Update Rollup externals so subpath SDK imports are not bundled.
- Add local ambient declarations for the migrated SDK entry points.
