### PR TITLE
fix: align inbound media maxBytes resolution with documented contract

### DIFF
--- a/src/agent/handler.ts
+++ b/src/agent/handler.ts
@@ -26,7 +26,11 @@ import { processDynamicRouting } from "../dynamic-routing.js";
 import { CHANNEL_ID, DEFAULT_MEDIA_MAX_MB } from "../const.js";
 
 function resolveWecomMediaMaxBytes(config: OpenClawConfig): number {
-    return (config.channels?.wecom?.media?.maxBytes as number | undefined) ?? DEFAULT_MEDIA_MAX_MB * 1024 * 1024;
+    const val = config.channels?.wecom?.media?.maxBytes as number | undefined;
+    if (typeof val === "number" && Number.isFinite(val) && val > 0) return val;
+    const mb = config.agents?.defaults?.mediaMaxMb;
+    if (typeof mb === "number" && Number.isFinite(mb) && mb > 0) return Math.floor(mb * 1024 * 1024);
+    return DEFAULT_MEDIA_MAX_MB * 1024 * 1024;
 }
 
 /** 错误提示信息 */

--- a/src/const.ts
+++ b/src/const.ts
@@ -92,8 +92,8 @@ export const MCP_CONFIG_FETCH_TIMEOUT_MS = 15_000;
 // 默认值
 // ============================================================================
 
-/** 默认媒体大小上限（MB） */
-export const DEFAULT_MEDIA_MAX_MB = 5;
+/** 默认媒体大小上限（MB），与 README 中 `channels.wecom.media.maxBytes` 的默认值 20MB 对齐 */
+export const DEFAULT_MEDIA_MAX_MB = 20;
 
 /** 文本分块大小上限 */
 export const TEXT_CHUNK_LIMIT = 4000;

--- a/src/media-handler.ts
+++ b/src/media-handler.ts
@@ -58,8 +58,13 @@ export async function downloadAndSaveImages(params: {
   for (const imageUrl of imageUrls) {
     try {
       runtime.log?.(`[wecom] Downloading image: url=${imageUrl}`);
+      // 优先级：channels.wecom.media.maxBytes > agents.defaults.mediaMaxMb > DEFAULT_MEDIA_MAX_MB
+      const wecomMaxBytes = config.channels?.wecom?.media?.maxBytes as number | undefined;
       const mediaMaxMb = config.agents?.defaults?.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
-      const maxBytes = mediaMaxMb * 1024 * 1024;
+      const maxBytes =
+        typeof wecomMaxBytes === "number" && Number.isFinite(wecomMaxBytes) && wecomMaxBytes > 0
+          ? wecomMaxBytes
+          : mediaMaxMb * 1024 * 1024;
 
       let imageBuffer: Buffer;
       let imageContentType: string;
@@ -131,8 +136,13 @@ export async function downloadAndSaveFiles(params: {
   for (const fileUrl of fileUrls) {
     try {
       runtime.log?.(`[wecom] Downloading file: url=${fileUrl}`);
+      // 优先级：channels.wecom.media.maxBytes > agents.defaults.mediaMaxMb > DEFAULT_MEDIA_MAX_MB
+      const wecomMaxBytes = config.channels?.wecom?.media?.maxBytes as number | undefined;
       const mediaMaxMb = config.agents?.defaults?.mediaMaxMb ?? DEFAULT_MEDIA_MAX_MB;
-      const maxBytes = mediaMaxMb * 1024 * 1024;
+      const maxBytes =
+        typeof wecomMaxBytes === "number" && Number.isFinite(wecomMaxBytes) && wecomMaxBytes > 0
+          ? wecomMaxBytes
+          : mediaMaxMb * 1024 * 1024;
 
       let fileBuffer: Buffer;
       let fileContentType: string;

--- a/src/webhook/helpers.ts
+++ b/src/webhook/helpers.ts
@@ -7,6 +7,7 @@
 
 import crypto from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_MEDIA_MAX_MB } from "../const.js";
 import type { StreamState, WecomWebhookTarget, WebhookInboundMessage, WebhookInboundQuote } from "./types.js";
 
 // ============================================================================
@@ -238,11 +239,15 @@ export function computeMd5(data: Buffer | string): string {
 
 /**
  * 解析媒体最大字节数（对齐原版 resolveWecomMediaMaxBytes）
+ *
+ * 优先级：channels.wecom.media.maxBytes > agents.defaults.mediaMaxMb > 20MB 兜底
  */
 export function resolveWecomMediaMaxBytes(cfg: OpenClawConfig): number {
   const val = (cfg.channels?.wecom as any)?.media?.maxBytes;
   if (typeof val === "number" && Number.isFinite(val) && val > 0) return val;
-  return 20 * 1024 * 1024; // 默认 20MB
+  const mb = cfg.agents?.defaults?.mediaMaxMb;
+  if (typeof mb === "number" && Number.isFinite(mb) && mb > 0) return Math.floor(mb * 1024 * 1024);
+  return DEFAULT_MEDIA_MAX_MB * 1024 * 1024; // 默认 20MB（由 const.ts 的 DEFAULT_MEDIA_MAX_MB 统一兜底）
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Aligns inbound media size limit resolution with the documented default for `channels.wecom.media.maxBytes` (20MB) and a consistent priority across code paths.

**Resolution order**

1. `channels.wecom.media.maxBytes` (when set to a finite positive number)
2. `agents.defaults.mediaMaxMb` × 1 MiB (compatibility fallback)
3. `20 * 1024 * 1024` bytes (documented default)

## Problem

Bot/WebSocket inbound media (`media-handler.ts`) used `agents.defaults.mediaMaxMb` with a 5MB constant fallback, so large inbound files could fail with a 5MB-style limit even when users expected the documented WeCom channel default (20MB).

## Changes

- `src/media-handler.ts`: local resolver + use for image/file download → `saveMediaBuffer` `maxBytes`
- `src/webhook/helpers.ts`: extend exported `resolveWecomMediaMaxBytes` with the same fallback chain
- `src/agent/handler.ts`: align local `resolveWecomMediaMaxBytes` with the same chain
- `src/webhook/helpers.test.ts`: unit tests for priority, invalid primary values, and a 10MB vs 20MB regression check

## How to test

```bash
npm run build
npx vitest run
```

## Notes

- Outbound WeCom limits (e.g. image 10MB downgrade in `media-uploader.ts`) are unchanged; this PR is inbound save / config resolution only.
