### PR TITLE
fix: keep admin group chats on shared route

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Dynamic Agent routing automatically creates isolated agents per user or group, e
 | `channels.wecom.dynamicAgents.enabled` | Enable dynamic agent routing | `false` |
 | `channels.wecom.dynamicAgents.dmCreateAgent` | Create isolated agent per DM user | `true` |
 | `channels.wecom.dynamicAgents.groupEnabled` | Enable dynamic agent for group chats | `true` |
-| `channels.wecom.dynamicAgents.adminUsers` | Admin users (bypass dynamic routing, use main agent) | `[]` |
+| `channels.wecom.dynamicAgents.adminUsers` | Admin users whose **DMs** bypass dynamic routing and use the main agent; group chats still follow group routing | `[]` |
 
 ---
 

--- a/src/dynamic-agent.ts
+++ b/src/dynamic-agent.ts
@@ -52,7 +52,7 @@ export function generateAgentId(chatType: "dm" | "group", peerId: string, accoun
  * **shouldUseDynamicAgent (检查是否使用动态 Agent)**
  *
  * 根据配置和发送者信息判断是否应使用动态 Agent。
- * 管理员（adminUsers）始终绕过动态路由，使用主 Agent。
+ * 管理员（adminUsers）仅在私聊中绕过动态路由，群聊始终按群维度共享路由。
  */
 export function shouldUseDynamicAgent(params: {
     chatType: "dm" | "group";
@@ -66,12 +66,12 @@ export function shouldUseDynamicAgent(params: {
         return false;
     }
 
-    // 管理员绕过动态路由
+    // 管理员仅绕过私聊动态路由，避免同一群按发送者拆成多个上下文。
     const sender = String(senderId).trim().toLowerCase();
     const isAdmin = dynamicConfig.adminUsers.some(
         (admin) => admin.trim().toLowerCase() === sender
     );
-    if (isAdmin) {
+    if (chatType === "dm" && isAdmin) {
         return false;
     }
 
@@ -80,5 +80,4 @@ export function shouldUseDynamicAgent(params: {
     }
     return dynamicConfig.dmCreateAgent;
 }
-
 

--- a/src/dynamic-routing.test.ts
+++ b/src/dynamic-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import { processDynamicRouting } from "./dynamic-routing.js";
+
+describe("processDynamicRouting", () => {
+  test("bypasses dynamic routing for admin direct messages", () => {
+    const result = processDynamicRouting({
+      route: {
+        agentId: "main",
+        sessionKey: "agent:main:wecom:default:dm:heye",
+        matchedBy: "default",
+        accountId: "default",
+      },
+      config: {
+        channels: {
+          wecom: {
+            dynamicAgents: {
+              enabled: true,
+              dmCreateAgent: true,
+              adminUsers: ["HeYe"],
+            },
+          },
+        },
+      } as any,
+      core: {} as any,
+      accountId: "default",
+      chatType: "dm",
+      chatId: "HeYe",
+      senderId: "HeYe",
+    });
+
+    expect(result.useDynamicAgent).toBe(false);
+    expect(result.finalAgentId).toBe("main");
+    expect(result.finalSessionKey).toBe("agent:main:wecom:default:dm:heye");
+    expect(result.routeModified).toBe(false);
+  });
+
+  test("keeps group chats on the shared dynamic route even when sender is admin", () => {
+    const result = processDynamicRouting({
+      route: {
+        agentId: "main",
+        sessionKey: "agent:main:wecom:default:group:wr123",
+        matchedBy: "default",
+        accountId: "default",
+      },
+      config: {
+        channels: {
+          wecom: {
+            dynamicAgents: {
+              enabled: true,
+              groupEnabled: true,
+              adminUsers: ["HeYe"],
+            },
+          },
+        },
+      } as any,
+      core: {} as any,
+      accountId: "default",
+      chatType: "group",
+      chatId: "wr123",
+      senderId: "HeYe",
+    });
+
+    expect(result.useDynamicAgent).toBe(true);
+    expect(result.finalAgentId).toBe("wecom-default-group-wr123");
+    expect(result.finalSessionKey).toBe("agent:wecom-default-group-wr123:wecom:default:group:wr123");
+    expect(result.routeModified).toBe(true);
+  });
+});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -94,6 +94,6 @@ export type WecomDynamicAgentsConfig = {
     dmCreateAgent?: boolean;
     /** 群聊：是否启用动态 Agent */
     groupEnabled?: boolean;
-    /** 管理员列表（绕过动态路由，使用主 Agent） */
+    /** 管理员列表（仅私聊绕过动态路由，使用主 Agent） */
     adminUsers?: string[];
 };


### PR DESCRIPTION
## Summary
- restrict `dynamicAgents.adminUsers` bypass to direct messages only
- keep group chats on the shared group dynamic route even when the sender is in `adminUsers`
- add regression tests and update config docs to match the behavior

## Verification
- `./node_modules/.bin/vitest src/dynamic-routing.test.ts`
- `./node_modules/.bin/tsc`

Closes #128