### PR TITLE
fix(media-handler): decrypt AES-CBC payload on fallback path (#125)

### DIFF
--- a/src/media-handler.ts
+++ b/src/media-handler.ts
@@ -7,6 +7,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { WSClient } from "@wecom/aibot-node-sdk";
+import { decryptFile } from "@wecom/aibot-node-sdk";
 import { fileTypeFromBuffer } from "file-type";
 import { getWeComRuntime } from "./runtime.js";
 import { IMAGE_DOWNLOAD_TIMEOUT_MS, FILE_DOWNLOAD_TIMEOUT_MS, DEFAULT_MEDIA_MAX_MB } from "./const.js";
@@ -70,6 +71,31 @@ async function detectImageContentType(data: Buffer): Promise<string> {
   return "application/octet-stream";
 }
 
+/**
+ * fallback 路径专用：当回退到 `fetchRemoteMedia` 时，这条路径只做 HTTP fetch，
+ * 不感知消息上下文中的 `aesKey`，落盘字节仍是 AES-CBC 密文。本辅助函数补上
+ * 解密步骤，保证下游 magic-byte 嗅探与 MIME 推断能拿到真实文件内容。
+ *
+ * 解密失败时（极少数 — 例如服务端真给了明文）退回原 buffer，由调用方自行决定。
+ */
+function tryDecryptWithAesKey(
+  buffer: Buffer,
+  aesKey: string | undefined,
+  runtime: RuntimeEnv,
+): Buffer {
+  if (!aesKey) return buffer;
+  try {
+    const decrypted = decryptFile(buffer, aesKey);
+    runtime.log?.(
+      `[wecom] Fallback decrypt OK: ${buffer.length} -> ${decrypted.length} bytes`,
+    );
+    return decrypted;
+  } catch (e) {
+    runtime.log?.(`[wecom] Fallback decrypt failed, keep raw: ${String(e)}`);
+    return buffer;
+  }
+}
+
 // ============================================================================
 // 图片下载和保存
 // ============================================================================
@@ -121,9 +147,13 @@ export async function downloadAndSaveImages(params: {
         ) as { buffer: Buffer; contentType?: string };
         runtime.log?.(`[wecom] Image fetched: contentType=${fetched.contentType}, size=${fetched.buffer.length}`);
 
-        imageBuffer = fetched.buffer;
-        imageContentType = fetched.contentType ?? "application/octet-stream";
-        const isValidImage = await isImageBuffer(fetched.buffer);
+        // fix: `fetchRemoteMedia` 仅做 HTTP fetch，不解密 AES-CBC，
+        // 直接落盘会导致 fileTypeFromBuffer 嗅探失败 → contentType 退化为
+        // application/octet-stream → 文件名缺扩展 → 下游 image 工具报
+        // "Unsupported media type: undefined"。此处补解密。
+        imageBuffer = tryDecryptWithAesKey(fetched.buffer, imageAesKey, runtime);
+        imageContentType = await detectImageContentType(imageBuffer);
+        const isValidImage = await isImageBuffer(imageBuffer);
 
         if (!isValidImage) {
           runtime.log?.(`[wecom] WARN: Downloaded data is not a valid image format`);
@@ -212,8 +242,11 @@ export async function downloadAndSaveFiles(params: {
         ) as { buffer: Buffer; contentType?: string };
         runtime.log?.(`[wecom] File fetched: contentType=${fetched.contentType}, size=${fetched.buffer.length}`);
 
-        fileBuffer = fetched.buffer;
-        fileContentType = fetched.contentType ?? "application/octet-stream";
+        // fix: 同图片分支，fallback 路径漏解密会导致下载文件 MD5 与原文件不一致
+        // （用户拿到的是密文），重新做 magic-byte 嗅探推 MIME。
+        fileBuffer = tryDecryptWithAesKey(fetched.buffer, fileAesKey, runtime);
+        const type = await fileTypeFromBuffer(fileBuffer);
+        fileContentType = type?.mime ?? fetched.contentType ?? "application/octet-stream";
       }
 
       // 大小校验由插件层主动进行，超限抛出 MediaOversizeError，由 monitor 统一提示用户。


### PR DESCRIPTION
## Summary

Fixes #125. Same root cause also covers the file-side symptom in #123 (downloaded file MD5 differs from original).

When the SDK primary path `wsClient.downloadFile(url, aesKey)` throws — in our environment this happens against Tencent COS signed URLs whenever the axios proxy / default-UA combination causes the upstream to return HTTP 400, while the equivalent `fetchRemoteMedia` call returns 200 OK — both `downloadAndSaveImages` and `downloadAndSaveFiles` fall back to `core.channel.media.fetchRemoteMedia({ url })`. That helper only does an HTTP fetch and is unaware of the per-message `aesKey`, so the bytes written to disk are still AES-CBC ciphertext.

Direct downstream impact:

- **Image** — `fileTypeFromBuffer` magic-byte sniff fails on ciphertext → `contentType` collapses to `application/octet-stream` → `saveMediaBuffer` cannot map a MIME to an extension → saved filename is a bare UUID with no `.jpg` / `.png` → agent `image` tool errors with `Unsupported media type: undefined`.
- **File** — bytes on disk are ciphertext → user downloads back a file whose MD5 doesn't match the original and which won't open. This is the user-facing symptom in #123.

## Fix

- Import `decryptFile` from `@wecom/aibot-node-sdk` (already a direct dep, used internally by `wsClient.downloadFile`).
- Add a small `tryDecryptWithAesKey(buffer, aesKey, runtime)` helper. If `aesKey` is absent it's a no-op; if `decryptFile` throws (server actually returned plaintext, key mismatch) it logs and keeps the raw buffer — never worse than current behavior.
- Apply it on **both** fallback branches:
  - image: re-run `detectImageContentType` / `isImageBuffer` against the decrypted buffer so MIME and the warning log reflect reality.
  - file: re-run `fileTypeFromBuffer` against the decrypted buffer so the inferred MIME flows into `saveMediaBuffer`.

The SDK primary path is unchanged — it already handles decryption internally via `decryptFile`.

## Test plan

- [x] `tsc --noEmit` passes (no new type errors).
- [x] Verified live on the failing message that originally surfaced #125: previously saved as `<uuid>` with `application/octet-stream`, post-patch saves as `<uuid>.jpg` with `image/jpeg` and the agent `image` tool consumes it successfully. Log line:
  ```
  [wecom] Fallback decrypt OK: 739616 -> 739587 bytes
  [wecom][plugin] Image saved: path=<state-dir>/media/inbound/<uuid>.jpg, contentType=image/jpeg
  ```
- [ ] (maintainers) wire the same helper into any future media-type fallbacks (video, voice) once those land — currently only image / file go through `fetchRemoteMedia`.

## Notes

The HTTP 400 against Tencent COS signed URLs that triggers the SDK→fallback transition is itself an upstream issue in `aibot-node-sdk` (likely default header / proxy agent interaction). Tracking it separately. Regardless of whether that gets fixed, the fallback path should still produce correct bytes when it is exercised — which is what this PR addresses.