### PR TITLE
fix: 修复 block/final 阶段文件重复发送的问题 (#150)

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -40,6 +40,10 @@ export interface MessageState {
   hasMedia?: boolean;
   /** 是否有媒体发送失败（权限不足、文件过大等） */
   hasMediaFailed?: boolean;
+
+  /** 本次回复中已发送过的 mediaUrl（用于 block/final 场景去重，防止文件重复发送） */
+  sentMediaUrls?: Set<string>;
+
   /** 媒体发送失败时的纯文本错误摘要（用于替换 thinking 流展示给用户） */
   mediaErrorSummary?: string;
   // /** deliver 回调是否被调用过（用于区分"核心无回复"和"核心回复了空内容"） */

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -580,14 +580,20 @@ async function routeAndDispatchMessage(params: {
           }
 
           // 发送媒体（统一走主动发送）
+          // 去重：过滤掉本次回复中已发送过的 mediaUrl（block/final 均会触发 deliver，防止文件重复发送）
           const mediaUrls = payload.mediaUrls?.length
             ? payload.mediaUrls
             : payload.mediaUrl
               ? [payload.mediaUrl]
               : [];
-          if (mediaUrls.length > 0) {
+          const newMediaUrls = mediaUrls.filter(
+            (url) => !state.sentMediaUrls?.has(url),
+          );
+          if (newMediaUrls.length > 0) {
+            state.sentMediaUrls ??= new Set();
+            newMediaUrls.forEach((url) => state.sentMediaUrls!.add(url));
             try {
-              await sendMediaBatch(ctx, mediaUrls);
+              await sendMediaBatch(ctx, newMediaUrls);
             } catch (mediaErr) {
               // sendMediaBatch 内部异常（如 getDefaultMediaLocalRoots 不可用等）
               // 必须标记 state，否则 finishThinkingStream 会显示"处理完成"误导用户


### PR DESCRIPTION
## 修复内容

**问题根因**：在流式回复场景下，`deliver` 回调会被 `block`（中间帧）和 `final`（最终帧）分别触发。当文件作为 `mediaUrls` 传递时，两个阶段都会独立调用 `sendMediaBatch`，导致同一个文件被发送两次。

**修复方案**：
1. 在 `MessageState` 接口中新增 `sentMediaUrls: Set<string>` 字段，用于记录本次回复中已发送过的 mediaUrl
2. 在 `deliver` 回调发送媒体前，过滤掉已记录过的 URL，只发送新的媒体文件
3. 新发送的 URL 会被加入 `sentMediaUrls`，下次触发时自动去重

**修改文件**：
- `src/interface.ts`：新增 `sentMediaUrls` 字段
- `src/monitor.ts`：在 `deliver` 回调中添加去重逻辑

**测试验证**：请参考 issue #150 中提供的日志，日志显示 block 和 final 阶段各发送了一次文件，修复后应只有 final 阶段发送一次。

---
对应 Issue：https://github.com/WecomTeam/wecom-openclaw-plugin/issues/150
