### PR TITLE
fix: support multi-account and CLI flags for DM policy

### DIFF
--- a/src/dm-policy.ts
+++ b/src/dm-policy.ts
@@ -73,9 +73,9 @@ export async function checkDmPolicy(params: {
       .catch(() => []);
 
   // 检查发送者是否在允许列表中
-  const storeAllowFrom = [...oldStoreAllowFrom, ...newStoreAllowFrom];
+  const storeEntries = dmPolicy === "allowlist" ? [] : [...oldStoreAllowFrom, ...newStoreAllowFrom];
 
-  const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+  const effectiveAllowFrom = [...configAllowFrom, ...storeEntries];
   const senderAllowedResult = isSenderAllowed(senderId, effectiveAllowFrom);
 
   if (senderAllowedResult) {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -9,7 +9,7 @@ import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import { addWildcardAllowFrom } from "./openclaw-compat.js";
 import type { WeComConfig } from "./utils.js";
-import { resolveWeComAccountMulti, setWeComAccountMulti } from "./accounts.js";
+import { resolveWeComAccountMulti, setWeComAccountMulti, resolveDefaultWeComAccountId } from "./accounts.js";
 import { CHANNEL_ID } from "./const.js";
 
 // ============================================================================
@@ -19,22 +19,23 @@ import { CHANNEL_ID } from "./const.js";
 export const wecomSetupAdapter: ChannelSetupAdapter = {
   applyAccountConfig: ({ cfg, input, accountId }) => {
     const patch: Partial<WeComConfig> = {};
+    const anyInput = input as any;
 
-        if (input.token !== undefined) {
+    if (input.token !== undefined) {
       patch.botId = String(input.token).trim();
     }
     if (input.privateKey !== undefined || input.secret !== undefined) {
       patch.secret = String(input.privateKey || input.secret).trim();
     }
-    if (input.dmPolicy !== undefined) {
-      patch.dmPolicy = (input.dmPolicy as any);
+    if (anyInput.dmPolicy !== undefined) {
+      patch.dmPolicy = anyInput.dmPolicy;
     }
-    if (input.dmAllowlist !== undefined) {
-      patch.allowFrom = Array.isArray(input.dmAllowlist)
-        ? (input.dmAllowlist as any)
-        : String(input.dmAllowlist)
+    if (anyInput.dmAllowlist !== undefined) {
+      patch.allowFrom = Array.isArray(anyInput.dmAllowlist)
+        ? anyInput.dmAllowlist
+        : String(anyInput.dmAllowlist)
             .split(/[,;]+/)
-            .map((s) => s.trim())
+            .map((s: string) => s.trim())
             .filter(Boolean);
     }
     if (input.name !== undefined) {
@@ -70,10 +71,10 @@ function setWeComDmPolicy(
       ? addWildcardAllowFrom(existingAllowFrom.map((x) => String(x)))
       : existingAllowFrom.map((x) => String(x));
 
-  return setWeComAccountMulti(cfg, { accountId,
+  return setWeComAccountMulti(cfg, {
     dmPolicy,
     allowFrom,
-  });
+  }, accountId);
 }
 
 const dmPolicy: ChannelSetupDmPolicy = {
@@ -81,11 +82,11 @@ const dmPolicy: ChannelSetupDmPolicy = {
   channel: CHANNEL_ID,
   policyKey: `channels.${CHANNEL_ID}.dmPolicy`,
   allowFromKey: `channels.${CHANNEL_ID}.allowFrom`,
-  getCurrent: ({ cfg, accountId }) => {
+  getCurrent: (cfg, accountId) => {
     const account = resolveWeComAccountMulti({ cfg, accountId });
     return (account.config.dmPolicy as any) ?? "open";
   },
-  setPolicy: ({ cfg, policy, accountId }) => {
+  setPolicy: (cfg, policy, accountId) => {
     return setWeComDmPolicy(cfg, policy, accountId);
   },
   promptAllowFrom: async ({ cfg, prompter, accountId }) => {
@@ -103,7 +104,7 @@ const dmPolicy: ChannelSetupDmPolicy = {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    return setWeComAccountMulti(cfg, { accountId, allowFrom });
+    return setWeComAccountMulti(cfg, { allowFrom }, accountId);
   },
 };
 
@@ -162,7 +163,7 @@ export const wecomSetupWizard: ChannelSetupWizard = {
         };
       },
       applySet: ({ cfg, resolvedValue, accountId }) => {
-        return setWeComAccountMulti(cfg, { accountId, botId: resolvedValue });
+        return setWeComAccountMulti(cfg, { botId: resolvedValue }, accountId);
       },
     },
     {
@@ -182,7 +183,7 @@ export const wecomSetupWizard: ChannelSetupWizard = {
         };
       },
       applySet: ({ cfg, resolvedValue, accountId }) => {
-        return setWeComAccountMulti(cfg, { accountId, secret: resolvedValue });
+        return setWeComAccountMulti(cfg, { secret: resolvedValue }, accountId);
       },
     },
   ],
@@ -192,7 +193,7 @@ export const wecomSetupWizard: ChannelSetupWizard = {
     // 确保配置完成后 channel 处于启用状态
     const account = resolveWeComAccountMulti({ cfg, accountId });
     if (account.botId?.trim() && account.secret?.trim() && !account.enabled) {
-      return { cfg: setWeComAccountMulti(cfg, { accountId, enabled: true }) };
+      return { cfg: setWeComAccountMulti(cfg, { enabled: true }, accountId) };
     }
     return undefined;
   },
@@ -215,6 +216,7 @@ export const wecomSetupWizard: ChannelSetupWizard = {
 
   // ── 禁用 ─────────────────────────────────────────────────────────────
   disable: (cfg) => {
-    return setWeComAccountMulti(cfg, { accountId, enabled: false });
+    const accountId = resolveDefaultWeComAccountId(cfg);
+    return setWeComAccountMulti(cfg, { enabled: false }, accountId);
   },
 };

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -17,23 +17,37 @@ import { CHANNEL_ID } from "./const.js";
 // ============================================================================
 
 export const wecomSetupAdapter: ChannelSetupAdapter = {
-  applyAccountConfig: ({ cfg, input }) => {
+  applyAccountConfig: ({ cfg, input, accountId }) => {
     const patch: Partial<WeComConfig> = {};
 
-    if (input.token !== undefined) {
+        if (input.token !== undefined) {
       patch.botId = String(input.token).trim();
     }
-    if (input.privateKey !== undefined) {
-      patch.secret = String(input.privateKey).trim();
+    if (input.privateKey !== undefined || input.secret !== undefined) {
+      patch.secret = String(input.privateKey || input.secret).trim();
+    }
+    if (input.dmPolicy !== undefined) {
+      patch.dmPolicy = (input.dmPolicy as any);
+    }
+    if (input.dmAllowlist !== undefined) {
+      patch.allowFrom = Array.isArray(input.dmAllowlist)
+        ? (input.dmAllowlist as any)
+        : String(input.dmAllowlist)
+            .split(/[,;]+/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+    }
+    if (input.name !== undefined) {
+      patch.name = String(input.name).trim();
     }
 
     // 如果是首次配置，默认启用
-    const account = resolveWeComAccountMulti({ cfg });
+    const account = resolveWeComAccountMulti({ cfg, accountId });
     if (!account.botId && !account.secret) {
       patch.enabled = true;
     }
 
-    return setWeComAccountMulti(cfg, patch);
+    return setWeComAccountMulti(cfg, patch, accountId);
   },
 };
 
@@ -47,15 +61,16 @@ export const wecomSetupAdapter: ChannelSetupAdapter = {
 function setWeComDmPolicy(
   cfg: OpenClawConfig,
   dmPolicy: "pairing" | "allowlist" | "open" | "disabled",
+  accountId?: string,
 ): OpenClawConfig {
-  const account = resolveWeComAccountMulti({ cfg });
+  const account = resolveWeComAccountMulti({ cfg, accountId });
   const existingAllowFrom = account.config.allowFrom ?? [];
   const allowFrom =
     dmPolicy === "open"
       ? addWildcardAllowFrom(existingAllowFrom.map((x) => String(x)))
       : existingAllowFrom.map((x) => String(x));
 
-  return setWeComAccountMulti(cfg, {
+  return setWeComAccountMulti(cfg, { accountId,
     dmPolicy,
     allowFrom,
   });
@@ -66,15 +81,15 @@ const dmPolicy: ChannelSetupDmPolicy = {
   channel: CHANNEL_ID,
   policyKey: `channels.${CHANNEL_ID}.dmPolicy`,
   allowFromKey: `channels.${CHANNEL_ID}.allowFrom`,
-  getCurrent: (cfg) => {
-    const account = resolveWeComAccountMulti({ cfg });
-    return account.config.dmPolicy ?? "open";
+  getCurrent: ({ cfg, accountId }) => {
+    const account = resolveWeComAccountMulti({ cfg, accountId });
+    return (account.config.dmPolicy as any) ?? "open";
   },
-  setPolicy: (cfg, policy) => {
-    return setWeComDmPolicy(cfg, policy);
+  setPolicy: ({ cfg, policy, accountId }) => {
+    return setWeComDmPolicy(cfg, policy, accountId);
   },
-  promptAllowFrom: async ({ cfg, prompter }) => {
-    const account = resolveWeComAccountMulti({ cfg });
+  promptAllowFrom: async ({ cfg, prompter, accountId }) => {
+    const account = resolveWeComAccountMulti({ cfg, accountId });
     const existingAllowFrom = account.config.allowFrom ?? [];
 
     const entry = await prompter.text({
@@ -88,7 +103,7 @@ const dmPolicy: ChannelSetupDmPolicy = {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    return setWeComAccountMulti(cfg, { allowFrom });
+    return setWeComAccountMulti(cfg, { accountId, allowFrom });
   },
 };
 
@@ -105,11 +120,11 @@ export const wecomSetupWizard: ChannelSetupWizard = {
     unconfiguredLabel: "需要 Bot ID 和 Secret",
     configuredHint: "已配置",
     unconfiguredHint: "需要设置",
-    resolveConfigured: ({ cfg }) => {
-      const account = resolveWeComAccountMulti({ cfg });
+    resolveConfigured: ({ cfg, accountId }) => {
+      const account = resolveWeComAccountMulti({ cfg, accountId });
       return Boolean(account.botId?.trim() && account.secret?.trim());
     },
-    resolveStatusLines: ({ cfg, configured }) => {
+    resolveStatusLines: ({ cfg, configured, accountId }) => {
       return [`企业微信: ${configured ? "已配置" : "需要 Bot ID 和 Secret"}`];
     },
   },
@@ -122,8 +137,8 @@ export const wecomSetupWizard: ChannelSetupWizard = {
       "1. Bot ID: 企业微信机器人 ID",
       "2. Secret: 企业微信机器人密钥",
     ],
-    shouldShow: ({ cfg }) => {
-      const account = resolveWeComAccountMulti({ cfg });
+    shouldShow: ({ cfg, accountId }) => {
+      const account = resolveWeComAccountMulti({ cfg, accountId });
       return !account.botId?.trim() || !account.secret?.trim();
     },
   },
@@ -137,8 +152,8 @@ export const wecomSetupWizard: ChannelSetupWizard = {
       envPrompt: "使用环境变量中的 Bot ID？",
       keepPrompt: "Bot ID 已配置，保留当前值？",
       inputPrompt: "企业微信机器人 Bot ID",
-      inspect: ({ cfg }) => {
-        const account = resolveWeComAccountMulti({ cfg });
+      inspect: ({ cfg, accountId }) => {
+        const account = resolveWeComAccountMulti({ cfg, accountId });
         const hasValue = Boolean(account.botId?.trim());
         return {
           accountConfigured: hasValue,
@@ -146,8 +161,8 @@ export const wecomSetupWizard: ChannelSetupWizard = {
           resolvedValue: account.botId || undefined,
         };
       },
-      applySet: ({ cfg, resolvedValue }) => {
-        return setWeComAccountMulti(cfg, { botId: resolvedValue });
+      applySet: ({ cfg, resolvedValue, accountId }) => {
+        return setWeComAccountMulti(cfg, { accountId, botId: resolvedValue });
       },
     },
     {
@@ -157,8 +172,8 @@ export const wecomSetupWizard: ChannelSetupWizard = {
       envPrompt: "使用环境变量中的 Secret？",
       keepPrompt: "Secret 已配置，保留当前值？",
       inputPrompt: "企业微信机器人 Secret",
-      inspect: ({ cfg }) => {
-        const account = resolveWeComAccountMulti({ cfg });
+      inspect: ({ cfg, accountId }) => {
+        const account = resolveWeComAccountMulti({ cfg, accountId });
         const hasValue = Boolean(account.secret?.trim());
         return {
           accountConfigured: hasValue,
@@ -166,18 +181,18 @@ export const wecomSetupWizard: ChannelSetupWizard = {
           resolvedValue: account.secret || undefined,
         };
       },
-      applySet: ({ cfg, resolvedValue }) => {
-        return setWeComAccountMulti(cfg, { secret: resolvedValue });
+      applySet: ({ cfg, resolvedValue, accountId }) => {
+        return setWeComAccountMulti(cfg, { accountId, secret: resolvedValue });
       },
     },
   ],
 
   // ── 完成后的最终处理 ──────────────────────────────────────────────────
-  finalize: async ({ cfg }) => {
+  finalize: async ({ cfg, accountId }) => {
     // 确保配置完成后 channel 处于启用状态
-    const account = resolveWeComAccountMulti({ cfg });
+    const account = resolveWeComAccountMulti({ cfg, accountId });
     if (account.botId?.trim() && account.secret?.trim() && !account.enabled) {
-      return { cfg: setWeComAccountMulti(cfg, { enabled: true }) };
+      return { cfg: setWeComAccountMulti(cfg, { accountId, enabled: true }) };
     }
     return undefined;
   },
@@ -189,8 +204,8 @@ export const wecomSetupWizard: ChannelSetupWizard = {
       "企业微信机器人已配置完成。",
       "运行 `openclaw start` 启动服务。",
     ],
-    shouldShow: ({ cfg }) => {
-      const account = resolveWeComAccountMulti({ cfg });
+    shouldShow: ({ cfg, accountId }) => {
+      const account = resolveWeComAccountMulti({ cfg, accountId });
       return Boolean(account.botId?.trim() && account.secret?.trim());
     },
   },
@@ -200,6 +215,6 @@ export const wecomSetupWizard: ChannelSetupWizard = {
 
   // ── 禁用 ─────────────────────────────────────────────────────────────
   disable: (cfg) => {
-    return setWeComAccountMulti(cfg, { enabled: false });
+    return setWeComAccountMulti(cfg, { accountId, enabled: false });
   },
 };


### PR DESCRIPTION
This PR fixes the account override issue in multi-account setups by correctly passing `accountId` through the onboarding flow. It also adds support for `dmPolicy` and `dmAllowlist` inputs, enabling these to be set via CLI flags (companion to openclaw/openclaw PR #84560).

---

### 🚀 Updated Updates (2026-05-20)

In addition to the multi-account fixes, this PR now includes:

1. **Strict DM Policy Enforcement**:
   - Fixed a bug in `src/dm-policy.ts` where the `allowlist` policy incorrectly merged historical pairing records. 
   - Now, when `dmPolicy` is set to `allowlist`, the plugin strictly honors the `allowFrom` configuration and ignores the pairing store.

2. **Onboarding Build Fixes**:
   - Resolved several TypeScript compilation errors in `src/onboarding.ts` caused by incorrect `setWeComAccountMulti` call signatures and type mismatches.
   - Ensured compatibility with the latest OpenClaw plugin-sdk types.

Verified locally: DM blocking now works correctly for users with pairing history, and the plugin builds successfully with `tsc`.